### PR TITLE
add name attribute to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "authorized_keys"
 maintainer       "Skalar AS"
 maintainer_email "gr@skalar.no"
 license          "All rights reserved"


### PR DESCRIPTION
Berkshelf fails to upload a cookbook with missing name attribute.
